### PR TITLE
rename dependencies label to our maintenance category

### DIFF
--- a/labels.js
+++ b/labels.js
@@ -127,6 +127,7 @@ module.exports = [
     description: "The necessary chores to keep the dust off.",
     aliases: [
        "chore",
+       "dependencies",
        "maintenance",
        "refactor",
        "testing",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "integrations-labels",
-  "version": "0.0.1",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "integrations-labels",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "A GitHub Action for applying issue/PR labels to Honeycomb integration/SDK projects.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Updating dependencies generally falls under "maintenance" unless they are addressing a security issue.