### PR TITLE
Add stalebot

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,22 @@
+name: 'Close stale issues and PRs'
+on: workflow_dispatch
+
+jobs:
+  stale:
+    name: 'Close stale issues and PRs'
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+
+    steps:
+      - uses: actions/stale@v4
+        with:
+          stale-issue-message: 'This issue is stale because it has been open 30 days with no activity.'
+          stale-pr-message: 'This PR is stale because it has been open 30 days with no activity.'
+          stale-issue-label: 'stale'
+          stale-pr-label: 'stale'
+          close-issue-message: 'This PR is being closed due to inactivity. Please see our [Honeycomb OSS Lifecyle and Practices](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md).'
+          close-pr-message: 'This PR is being closed due to inactivity. Please see our [Honeycomb OSS Lifecyle and Practices](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md).'
+          days-before-stale: 30
+          days-before-close: 7

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,5 +1,5 @@
 name: 'Close stale issues and PRs'
-on: workflow_dispatch
+on: workflow_dispatch # only run on demand in Actions
 
 jobs:
   stale:
@@ -12,11 +12,12 @@ jobs:
     steps:
       - uses: actions/stale@v4
         with:
-          stale-issue-message: 'This issue is stale because it has been open 30 days with no activity.'
-          stale-pr-message: 'This PR is stale because it has been open 30 days with no activity.'
+          stale-issue-message: 'This issue is stale because it has been open 30 days with no activity. Please add a comment if this is still an ongoing issue; otherwise this issue will be automatically closed in 7 days.'
+          stale-pr-message: 'This PR is stale because it has been open 30 days with no activity. Please add a comment if this PR is still needed; otherwise this PR will be automatically closed in 7 days.'
           stale-issue-label: 'stale'
           stale-pr-label: 'stale'
-          close-issue-message: 'This PR is being closed due to inactivity. Please see our [Honeycomb OSS Lifecyle and Practices](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md).'
+          close-issue-message: 'This issue is being closed due to inactivity. Please see our [Honeycomb OSS Lifecyle and Practices](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md).'
           close-pr-message: 'This PR is being closed due to inactivity. Please see our [Honeycomb OSS Lifecyle and Practices](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md).'
-          days-before-stale: 30
+          days-before-pr-stale: 30
+          days-before-issue-stale: 14
           days-before-close: 7

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -18,4 +18,5 @@ jobs:
           close-pr-message: 'Closing this PR due to inactivity. Please see our [Honeycomb OSS Lifecyle and Practices](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md).'
           days-before-issue-stale: 14
           days-before-pr-stale: 30
-          days-before-close: 7
+          days-before-issue-close: 7
+          days-before-pr-close: 7

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -14,7 +14,7 @@ jobs:
         with:
           start-date: '2021-01-09T00:00:00Z' # Starting Sept 1, 2021
           stale-issue-message: 'Marking this issue as stale because it has been open 14 days with no activity. Please add a comment if this is still an ongoing issue; otherwise this issue will be automatically closed in 7 days.'
-          stale-pr-message: 'Marking this PR as stale because it has been open 30 days with no activity. Please add a comment if this PR is still needed; otherwise this PR will be automatically closed in 7 days.'
+          stale-pr-message: 'Marking this PR as stale because it has been open 30 days with no activity. Please add a comment if this PR is still relevant; otherwise this PR will be automatically closed in 7 days.'
           close-issue-message: 'Closing this issue due to inactivity. Please see our [Honeycomb OSS Lifecyle and Practices](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md).'
           close-pr-message: 'Closing this PR due to inactivity. Please see our [Honeycomb OSS Lifecyle and Practices](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md).'
           days-before-issue-stale: 14

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -12,6 +12,7 @@ jobs:
     steps:
       - uses: actions/stale@v4
         with:
+          start-date: '2021-01-09T00:00:00Z' # Starting Sept 1, 2021
           stale-issue-message: 'Marking this issue as stale because it has been open 14 days with no activity. Please add a comment if this is still an ongoing issue; otherwise this issue will be automatically closed in 7 days.'
           stale-pr-message: 'Marking this PR as stale because it has been open 30 days with no activity. Please add a comment if this PR is still needed; otherwise this PR will be automatically closed in 7 days.'
           close-issue-message: 'Closing this issue due to inactivity. Please see our [Honeycomb OSS Lifecyle and Practices](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md).'

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -12,12 +12,12 @@ jobs:
     steps:
       - uses: actions/stale@v4
         with:
-          stale-issue-message: 'This issue is stale because it has been open 30 days with no activity. Please add a comment if this is still an ongoing issue; otherwise this issue will be automatically closed in 7 days.'
-          stale-pr-message: 'This PR is stale because it has been open 30 days with no activity. Please add a comment if this PR is still needed; otherwise this PR will be automatically closed in 7 days.'
+          stale-issue-message: 'Marking this issue as stale because it has been open 14 days with no activity. Please add a comment if this is still an ongoing issue; otherwise this issue will be automatically closed in 7 days.'
+          stale-pr-message: 'Marking this PR as stale because it has been open 30 days with no activity. Please add a comment if this PR is still needed; otherwise this PR will be automatically closed in 7 days.'
           stale-issue-label: 'stale'
           stale-pr-label: 'stale'
-          close-issue-message: 'This issue is being closed due to inactivity. Please see our [Honeycomb OSS Lifecyle and Practices](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md).'
-          close-pr-message: 'This PR is being closed due to inactivity. Please see our [Honeycomb OSS Lifecyle and Practices](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md).'
-          days-before-pr-stale: 30
+          close-issue-message: 'Closing this issue due to inactivity. Please see our [Honeycomb OSS Lifecyle and Practices](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md).'
+          close-pr-message: 'Closing this PR due to inactivity. Please see our [Honeycomb OSS Lifecyle and Practices](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md).'
           days-before-issue-stale: 14
+          days-before-pr-stale: 30
           days-before-close: 7

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -14,8 +14,6 @@ jobs:
         with:
           stale-issue-message: 'Marking this issue as stale because it has been open 14 days with no activity. Please add a comment if this is still an ongoing issue; otherwise this issue will be automatically closed in 7 days.'
           stale-pr-message: 'Marking this PR as stale because it has been open 30 days with no activity. Please add a comment if this PR is still needed; otherwise this PR will be automatically closed in 7 days.'
-          stale-issue-label: 'stale'
-          stale-pr-label: 'stale'
           close-issue-message: 'Closing this issue due to inactivity. Please see our [Honeycomb OSS Lifecyle and Practices](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md).'
           close-pr-message: 'Closing this PR due to inactivity. Please see our [Honeycomb OSS Lifecyle and Practices](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md).'
           days-before-issue-stale: 14

--- a/stale/README.md
+++ b/stale/README.md
@@ -2,7 +2,7 @@
 
 A [Github Action](https://github.com/actions/stale) to automate labeling and closing of issues and PRs that have not had activity for a number of days (become stale).
 
-Because this is a built-in stale action, no additional files are needed.
+Because this is a pre-built stale action, no additional files are needed.
 
 The current workflow is only [run on demand](https://docs.github.com/en/actions/reference/events-that-trigger-workflows#manual-events) (`on: workflow_dispatch`) until finalized, then can be adjusted to a schedule via cron job.
 
@@ -12,12 +12,15 @@ See detailed options in [actions/stale#details-options](https://github.com/actio
 
 Used in this workflow:
 
+- `start-date`
 - `stale-issue-message`
 - `stale-pr-message`
-- `stale-issue-label`
-- `stale-pr-label`
-- `days-before-stale`
-- `days-before-close`
+- `close-issue-message`
+- `close-pr-message`
+- `days-before-issue-stale`
+- `days-before-pr-stale`
+- `days-before-issue-close`
+- `days-before-pr-close`
 
 ## Outputs
 

--- a/stale/README.md
+++ b/stale/README.md
@@ -1,0 +1,53 @@
+# Stalebot
+
+A [Github Action](https://github.com/actions/stale) to automate labeling and closing of issues and PRs that have not had activity for a number of days (become stale).
+
+Because this is a built-in stale action, no additional files are needed.
+
+The current workflow is only [run on demand](https://docs.github.com/en/actions/reference/events-that-trigger-workflows#manual-events) (`on: workflow_dispatch`) until finalized, then can be adjusted to a schedule via cron job.
+
+## Inputs
+
+See detailed options in [actions/stale#details-options](https://github.com/actions/stale#detailed-options).
+
+Used in this workflow:
+
+- `stale-issue-message`
+- `stale-pr-message`
+- `stale-issue-label`
+- `stale-pr-label`
+- `days-before-stale`
+- `days-before-close`
+
+## Outputs
+
+No outputs.
+
+## Example usage
+
+Create a workflow file in your GitHub repository:
+
+```plain
+.github/workflows/stale.yml
+```
+
+Include in it the action configuration:
+
+```yaml
+name: 'Close stale issues and PRs'
+on:
+  schedule:
+    - cron: '30 1 * * *'
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v4
+        with:
+          stale-issue-message: 'This issue is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 5 days.'
+          days-before-stale: 30
+          days-before-close: 5
+```
+
+More usage examples in [actions/stale#usage](https://github.com/actions/stale#usage).


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- Adds Stalebot - automation for issues and PRs that have not had activity for X number of days.

## Short description of the changes

- A [Github Action](https://github.com/actions/stale) to automate labeling and closing of issues and PRs that have not had activity for a number of days (become stale).
- The current workflow is only [run on demand](https://docs.github.com/en/actions/reference/events-that-trigger-workflows#manual-events) (`on: workflow_dispatch`) until finalized, then can be adjusted to a schedule via cron scheduler.

Used in this workflow:

- `start-date`
- `stale-issue-message`
- `stale-pr-message`
- `close-issue-message`
- `close-pr-message`
- `days-before-issue-stale`
- `days-before-pr-stale`
- `days-before-issue-close`
- `days-before-pr-close`

