### PR TITLE
maint: add instructions, update stale workflow, add re-triage workflow

### DIFF
--- a/.github/workflows/re-triage.yml
+++ b/.github/workflows/re-triage.yml
@@ -1,0 +1,13 @@
+
+name: Re-triage issues with new comments
+on:
+  issue_comment:
+    types: [created]
+jobs:
+  re-triage:
+    runs-on: ubuntu-latest
+    name: Re-triage issues with new comments
+    steps:
+      - uses: honeycombio/oss-management-actions/re-triage@v1
+        with:
+          ghprojects-token: ${{ secrets.GHPROJECTS_TOKEN }}

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,5 +1,7 @@
 name: 'Close stale issues and PRs'
-on: workflow_dispatch # only run on demand in Actions
+on:
+  schedule:
+    - cron: '30 1 * * *'
 
 jobs:
   stale:

--- a/README.md
+++ b/README.md
@@ -1,3 +1,14 @@
 # Honeycomb OSS Management Actions
 
 A set of [GitHub Actions](https://docs.github.com/en/free-pro-team@latest/actions/creating-actions/creating-a-javascript-action) to apply a common set of OSS management workflows to Honeycomb projects.
+
+Each action has a `README.md` file explaining its usage and inputs/outputs.
+
+The general process of adding the workflow to a new repo is to simply add the `.yml` file to your repo's directory `.github/workflows`, as also seen in this repo's directory.
+
+## Actions
+
+- [Add to Project Board](./projects)
+- [Apply common labels](./labels)
+- [Re-triage updated issues](./re-triage)
+- [Apply stale rules](./stale)

--- a/stale/README.md
+++ b/stale/README.md
@@ -4,8 +4,6 @@ A [Github Action](https://github.com/actions/stale) to automate labeling and clo
 
 Because this is a pre-built stale action, no additional files are needed.
 
-The current workflow is only [run on demand](https://docs.github.com/en/actions/reference/events-that-trigger-workflows#manual-events) (`on: workflow_dispatch`) until finalized, then can be adjusted to a schedule via cron job.
-
 ## Inputs
 
 See detailed options in [actions/stale#details-options](https://github.com/actions/stale#detailed-options).
@@ -21,6 +19,7 @@ Used in this workflow:
 - `days-before-pr-stale`
 - `days-before-issue-close`
 - `days-before-pr-close`
+- `any-of-labels`
 
 ## Outputs
 
@@ -44,13 +43,25 @@ on:
 
 jobs:
   stale:
+    name: 'Close stale issues and PRs'
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+
     steps:
       - uses: actions/stale@v4
         with:
-          stale-issue-message: 'This issue is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 5 days.'
-          days-before-stale: 30
-          days-before-close: 5
+          start-date: '2021-09-01T00:00:00Z' # Starting Sept 1, 2021
+          stale-issue-message: 'Marking this issue as stale because it has been open 14 days with no activity. Please add a comment if this is still an ongoing issue; otherwise this issue will be automatically closed in 7 days.'
+          stale-pr-message: 'Marking this PR as stale because it has been open 30 days with no activity. Please add a comment if this PR is still relevant; otherwise this PR will be automatically closed in 7 days.'
+          close-issue-message: 'Closing this issue due to inactivity. Please see our [Honeycomb OSS Lifecyle and Practices](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md).'
+          close-pr-message: 'Closing this PR due to inactivity. Please see our [Honeycomb OSS Lifecyle and Practices](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md).'
+          days-before-issue-stale: 14
+          days-before-pr-stale: 30
+          days-before-issue-close: 7
+          days-before-pr-close: 7
+          any-of-labels: 'status: info needed,status: revision needed'
 ```
 
 More usage examples in [actions/stale#usage](https://github.com/actions/stale#usage).


### PR DESCRIPTION
Changes:

- Update main `README.md` with general instructions on usage
- Add re-triage workflow to this repo
- Update stale workflow with cron schedule as used in our repos (instead of on-demand)
- Update stale `README.md` with current state to match our other repos