### PR TITLE
add an "oncall" status label

### DIFF
--- a/labels/labels.js
+++ b/labels/labels.js
@@ -92,6 +92,11 @@ module.exports = [
     description: "Further information is requested."
  },
  {
+    name: "status: oncall",
+    color: colors.velvet,
+    description: "Flagged for awareness from Honeycomb Telemetry Oncall"
+ },
+ {
     name: "type: bug",
     color: colors.crimson,
     aliases: [


### PR DESCRIPTION
To label an issue or PR as currently in the oncall work queue. "status: " seemed
to make the most sense for a category to put this label under.

[Velvet's a nice deep purple color](https://color-hex.org/color/593380). Soothing.

![That's beautiful. What is that? Velvet?](https://user-images.githubusercontent.com/517302/166252197-6b8722f1-4dd8-4942-9c1a-44c5d3766027.gif)

