### PR TITLE
maint: update node12 to node16

### DIFF
--- a/labels/action.yml
+++ b/labels/action.yml
@@ -5,5 +5,5 @@ inputs:
     description: The GitHub token used to apply labels.
     required: true
 runs:
-  using: node12
+  using: node16
   main: index.js

--- a/projects/action.yml
+++ b/projects/action.yml
@@ -5,5 +5,5 @@ inputs:
     description: The GitHub token used to add issues and prs to projects.
     required: true
 runs:
-  using: node12
+  using: node16
   main: index.js

--- a/re-triage/action.yml
+++ b/re-triage/action.yml
@@ -5,5 +5,5 @@ inputs:
     description: The GitHub token used to add issues and prs to projects.
     required: true
 runs:
-  using: node12
+  using: node16
   main: index.js


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- Warning on actions mentioning that Node12 actions are deprecated, suggesting to use Node 16

> Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: honeycombio/oss-management-actions

## Short description of the changes

- update node12 to node16 for each action [specifying that version](https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#runs-for-javascript-actions)

## How to verify that this has the expected result

no more warnings on action workflows 