### PR TITLE
maint: add new project workflow

### DIFF
--- a/.github/workflows/add-to-project-v2.yml
+++ b/.github/workflows/add-to-project-v2.yml
@@ -1,0 +1,15 @@
+name: Add to project
+on:
+  issues:
+    types: [opened]
+  pull_request_target:
+    types: [opened]
+jobs:
+  add-to-project:
+    runs-on: ubuntu-latest
+    name: Add issues and PRs to project
+    steps:
+      - uses: actions/add-to-project@main
+        with:
+          project-url: https://github.com/orgs/honeycombio/projects/11
+          github-token: ${{ secrets.GHPROJECTS_TOKEN }}


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- missing new workflow on this repo

## Short description of the changes

add new project workflow as seen in our other repos

## How to verify that this has the expected result

new issues/prs should show up on our new (internal) project board