### PR TITLE
maint: Update action node version to 20

### DIFF
--- a/labels/action.yml
+++ b/labels/action.yml
@@ -5,5 +5,5 @@ inputs:
     description: The GitHub token used to apply labels.
     required: true
 runs:
-  using: node16
+  using: node20
   main: index.js

--- a/projects/action.yml
+++ b/projects/action.yml
@@ -5,5 +5,5 @@ inputs:
     description: The GitHub token used to add issues and prs to projects.
     required: true
 runs:
-  using: node16
+  using: node20
   main: index.js

--- a/re-triage/action.yml
+++ b/re-triage/action.yml
@@ -5,5 +5,5 @@ inputs:
     description: The GitHub token used to add issues and prs to projects.
     required: true
 runs:
-  using: node16
+  using: node20
   main: index.js


### PR DESCRIPTION
## Which problem is this PR solving?

Github actions no longer supports node16 and is being forced to run on Node20 and other projects that use these actions see the following warnin:

<img width="1171" alt="image" src="https://github.com/user-attachments/assets/d346a209-3375-4165-a2de-6f45585526e7">

This PR updates the actions to use node20 directly.

## Short description of the changes

- Update the actions to use node20
